### PR TITLE
Use golangci-lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-
   build:
     name: Build
     env:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,37 @@
+name: golangci-lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the action will use pre-installed Go.
+          # skip-go-installation: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,133 @@
+# https://golangci-lint.run/usage/configuration/
+
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 2m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # include test files or not, default is true
+  tests: false
+
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value (see skip-dirs-use-default).
+  # "/" will be replaced by current OS file path separator to properly work
+  # on Windows.
+  skip-dirs:
+    - node_modules
+
+  # default is true. Enables skipping of directories:
+  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs-use-default: true
+
+  # Allow multiple parallel golangci-lint instances running.
+  # If false (default) - golangci-lint acquires file lock on start.
+  allow-parallel-runners: false
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  # default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
+  # add a prefix to the output file references; default is no prefix
+  path-prefix: ""
+
+  # sorts results by: filepath, line and column
+  sort-results: false
+
+# all available settings of specific linters
+linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: false
+
+  dupl:
+    # tokens count to trigger issue, 150 by default
+    threshold: 100
+
+  errcheck:
+    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: false
+
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    # default is false: such cases aren't reported by default.
+    check-blank: false
+
+  gocognit:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 20
+
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 3
+
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 20
+
+  golint:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0
+
+  prealloc:
+    # XXX: we don't recommend using this linter before doing performance profiling.
+    # For most programs usage of prealloc will be a premature optimization.
+
+    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+    # True by default.
+    simple: true
+    range-loops: true # Report preallocation suggestions on range loops, true by default
+    for-loops: false # Report preallocation suggestions on for loops, false by default
+
+  whitespace:
+    # Enforces newlines (or comments) after every multi-line if statement
+    multi-if: true
+
+    # Enforces newlines (or comments) after every multi-line function signature
+    multi-func: true
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dupl
+    - errcheck
+    - gocognit
+    - goconst
+    - gocyclo
+    - golint
+    - gosimple
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - prealloc
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+    - whitespace

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "go.lintTool":"golangci-lint",
+    "go.lintFlags": [
+      "--fast"
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,7 @@ ifeq ($(CI),true)
 else
 	npm install
 endif
-	go get golang.org/x/lint/golint
-	go get github.com/securego/gosec/cmd/gosec
-	go get github.com/kisielk/errcheck
-	go get honnef.co/go/tools/cmd/staticcheck
-	go get github.com/golang/mock/mockgen
+	go install github.com/golang/mock/mockgen@v1.5.0
 	go generate $(GO_CODE_PATH)
 
 .PHONY: clean
@@ -47,27 +43,20 @@ clean: ## Clean the local filesystem
 ##
 
 .PHONY: vet
-vet: vet-go vet-cdk ## Vet the code
+vet: vet-go lint-cdk ## Vet the code
 
 .PHONY: vet-go
 vet-go: ## Vet the Go code
 	@echo "Vet the Go code..."
 	go vet -v $(GO_CODE_PATH)
 
+.PHONY: lint-go
+lint-go: ## Lint the Go code
 	@echo "Lint the Go code..."
-	$$GOPATH/bin/golint -set_exit_status $(shell go list $(GO_CODE_PATH))
+	golangci-lint run
 
-	@echo "Error check the Go code..."
-	$$GOPATH/bin/errcheck $(GO_CODE_PATH)
-
-	@echo "Perform static analysis on the Go code..."
-	$$GOPATH/bin/staticcheck $(GO_CODE_PATH)
-
-	@echo "Inspect Go code for security vulnerabilities..."
-	$$GOPATH/bin/gosec -exclude-dir build $(GO_CODE_PATH)
-
-.PHONY: vet-cdk
-vet-cdk: ## Vet the CDK code
+.PHONY: lint-cdk
+lint-cdk: ## Lint the CDK code
 	@echo "Lint the CDK code..."
 	npm run lint
 

--- a/src/lib/matcher/guid_test.go
+++ b/src/lib/matcher/guid_test.go
@@ -60,7 +60,6 @@ func TestMatches(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestString(t *testing.T) {

--- a/src/lib/traveline/client.go
+++ b/src/lib/traveline/client.go
@@ -109,7 +109,7 @@ func (c *Client) Send(request string) (string, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		log.Printf("Error response from API: %v", resp)
-		return string(body), errors.Errorf("Error status from API: %d", resp.StatusCode)
+		return string(body), errors.Errorf("error status from API: %d", resp.StatusCode)
 	}
 
 	return string(body), nil

--- a/src/lib/traveline/client_test.go
+++ b/src/lib/traveline/client_test.go
@@ -219,7 +219,7 @@ func TestSend(t *testing.T) {
 			response:         "Invalid user credentials",
 			statusCode:       http.StatusUnauthorized,
 			expectedResponse: "Invalid user credentials",
-			expectedError:    errors.New("Error status from API: 401"),
+			expectedError:    errors.New("error status from API: 401"),
 		},
 	}
 	for _, test := range tests {
@@ -274,7 +274,7 @@ func TestSend(t *testing.T) {
 func TestSendDoFails(t *testing.T) {
 	client := NewTestClient(func(req *http.Request) (*http.Response, error) {
 		// Return an error so that Client.Do(req) fails
-		return nil, errors.New("Bang")
+		return nil, errors.New("bang")
 	})
 
 	tlClient := traveline.NewClient(


### PR DESCRIPTION
Use golangci-lint instead of installing individual linters.

Add configuration file with the following linters:
- bodyclose
- deadcode
- depguard
- dupl
- errcheck
- gocognit
- goconst
- gocyclo
- golint
- gosimple
- gosec
- govet
- ineffassign
- misspell
- prealloc
- staticcheck
- structcheck
- typecheck
- unused
- varcheck
- whitespace