### PR TITLE
Update Lambda binary filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Go
 coverage.out
 lambda/*/handler.zip
-lambda/*/main
+lambda/*/bootstrap
 mock/
 bin/
 

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ DIRS=$(shell find lambda/* -type d)
 .PHONY: builders $(DIRS)
 builders: $(DIRS) ## Build all the underlying lambdas
 
-$(DIRS): ## Build each lambda
-	cd $@ && GOOS=linux go build -o main ./...
+$(DIRS): ## Build each lambda - https://www.wolfe.id.au/2023/08/09/rip-aws-go-lambda-runtime/#why-is-this-hard
+	cd $@ && GOOS=linux go build -o bootstrap ./...
 
 .PHONY: build-cdk
 build-cdk: ## Build the CDK stacks

--- a/infrastructure/lib/constructs/get-next-tram-lambda.ts
+++ b/infrastructure/lib/constructs/get-next-tram-lambda.ts
@@ -97,7 +97,7 @@ export class GetNextTramLambda extends Construct {
       functionName: name + "-lambda",
       description: "Lambda function that will get the next tram",
       code: lambda.Code.fromAsset("lambda/get-next-tram"),
-      handler: "main",
+      handler: "bootstrap",
       runtime: lambda.Runtime.PROVIDED_AL2,
       memorySize: props.memorySize,
       timeout: Duration.seconds(props.timeout),

--- a/infrastructure/test/constructs/get-next-tram-lambda.test.ts
+++ b/infrastructure/test/constructs/get-next-tram-lambda.test.ts
@@ -29,7 +29,7 @@ test("Lambda is created with parameters given", () => {
   template.hasResourceProperties("AWS::Lambda::Function", {
     FunctionName: "get-next-tram-lambda",
     Description: "Lambda function that will get the next tram",
-    Handler: "main",
+    Handler: "bootstrap",
     Runtime: "provided.al2",
     Environment: {
       Variables: {

--- a/infrastructure/test/next-next-tram.test.ts
+++ b/infrastructure/test/next-next-tram.test.ts
@@ -22,7 +22,7 @@ test("Stack is created with lambda", () => {
   template.hasResourceProperties("AWS::Lambda::Function", {
     FunctionName: "get-next-tram-lambda",
     Description: "Lambda function that will get the next tram",
-    Handler: "main",
+    Handler: "bootstrap",
     Runtime: "provided.al2",
     Environment: {
       Variables: {


### PR DESCRIPTION
Seems it has to be called "bootstrap" when using the provided.al2 Lambda runtime.

https://www.wolfe.id.au/2023/08/09/rip-aws-go-lambda-runtime/#why-is-this-hard https://www.capitalone.com/tech/cloud/custom-runtimes-for-go-based-lambda-functions/